### PR TITLE
Update port settings for selenium V4

### DIFF
--- a/terraform/chrome.task.json
+++ b/terraform/chrome.task.json
@@ -18,12 +18,16 @@
         ],
         "environment": [
             {
-                "name": "HUB_HOST",
+                "name": "SE_EVENT_BUS_HOST",
                 "value": "hub.${app_name}"
             },
             {
-                "name": "HUB_PORT",
-                "value": "4444"
+                "name": "SE_EVENT_BUS_PUBLISH_PORT",
+                "value": "4442"
+            },
+            {
+                "name": "SE_EVENT_BUS_SUBSCRIBE_PORT",
+                "value": "4443"
             },
             {
                 "name": "NODE_MAX_SESSION",

--- a/terraform/firefox.task.json
+++ b/terraform/firefox.task.json
@@ -18,12 +18,16 @@
         ],
         "environment": [
             {
-                "name": "HUB_HOST",
+                "name": "SE_EVENT_BUS_HOST",
                 "value": "hub.${app_name}"
             },
             {
-                "name": "HUB_PORT",
-                "value": "4444"
+                "name": "SE_EVENT_BUS_PUBLISH_PORT",
+                "value": "4442"
+            },
+            {
+                "name": "SE_EVENT_BUS_SUBSCRIBE_PORT",
+                "value": "4443"
             },
             {
                 "name": "NODE_MAX_SESSION",

--- a/terraform/hub.task.json
+++ b/terraform/hub.task.json
@@ -4,9 +4,19 @@
         "image": "${image}", 
         "portMappings": [
             {
-            "hostPort": 4444,
-            "protocol": "tcp",
-            "containerPort": 4444
+                "hostPort": 4442,
+                "protocol": "tcp",
+                "containerPort": 4442
+            },
+            {
+                "hostPort": 4443,
+                "protocol": "tcp",
+                "containerPort": 4443
+            },
+            {
+                "hostPort": 4444,
+                "protocol": "tcp",
+                "containerPort": 4444
             }
         ], 
         "essential": true, 


### PR DESCRIPTION
Try to address nodes not registered issue after upgrading images https://www.pivotaltracker.com/n/projects/2328629/stories/181158061/comments/230128604
Comparing setup from V3 and V4, try to update env variables and port mappings in the terraform script


V3 setup https://github.com/SeleniumHQ/docker-selenium/tree/selenium-3
$ docker network create grid
$ docker run -d -p 4444:4444 --net grid --name selenium-hub selenium/hub:3.141.59-20210929
$ docker run -d --net grid -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-chrome:3.141.59-20210929
$ docker run -d --net grid -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-firefox:3.141.59-20210929
$ docker run -d --net grid -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-opera:3.141.59-20210929


V4 setup https://github.com/SeleniumHQ/docker-selenium/tree/trunk
$ docker network create grid
$ docker run -d -p 4442-4444:4442-4444 --net grid --name selenium-hub selenium/hub:4.1.2-20220217
$ docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub \
    --shm-size="2g" \
    -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
    -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
    selenium/node-chrome:4.1.2-20220217
$ docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub \
    --shm-size="2g" \
    -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
    -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
    selenium/node-edge:4.1.2-20220217
$ docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub \
    --shm-size="2g" \
    -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
    -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
    selenium/node-firefox:4.1.2-20220217