### PR TITLE
workaround to pass settings to allow auto-scaling

### DIFF
--- a/terraform/chrome.task.json
+++ b/terraform/chrome.task.json
@@ -30,12 +30,8 @@
                 "value": "4443"
             },
             {
-                "name": "NODE_MAX_SESSION",
-                "value": "6"
-            },
-            {
-                "name": "NODE_MAX_INSTANCES",
-                "value": "6"
+                "name": "SE_OPTS",
+                "value": "--override-max-sessions true --max-sessions 6 --session-timeout 7200"
             },
             {
                 "name": "SCREEN_HEIGHT",

--- a/terraform/firefox.task.json
+++ b/terraform/firefox.task.json
@@ -30,12 +30,8 @@
                 "value": "4443"
             },
             {
-                "name": "NODE_MAX_SESSION",
-                "value": "6"
-            },
-            {
-                "name": "NODE_MAX_INSTANCES",
-                "value": "6"
+                "name": "SE_OPTS",
+                "value": "--override-max-sessions true --max-sessions 6 --session-timeout 7200"
             },
             {
                 "name": "SCREEN_HEIGHT",


### PR DESCRIPTION
Found out auto-scaling was broken with our selenium grid instance with yesterday's trial runs.
it looks like the max sessions per node was not being picked up when we tried to upgrade to selenium 4, and since it default to 1, the CPU threshold would never be reached to 90% to kick off auto-scaling. 
By referring following ticket https://github.com/SeleniumHQ/docker-selenium/issues/1319
I put together this PR to set the env variable needed and hope this could resolve the problem.