### PR TITLE
Try update cpu threshold and use regular env variables

### DIFF
--- a/terraform/chrome.task.json
+++ b/terraform/chrome.task.json
@@ -30,8 +30,12 @@
                 "value": "4443"
             },
             {
-                "name": "SE_OPTS",
-                "value": "--override-max-sessions true --max-sessions 6 --session-timeout 7200"
+                "name": "SE_NODE_MAX_SESSIONS",
+                "value": "6"
+            },
+            {
+                "name": "SE_NODE_OVERRIDE_MAX_SESSIONS",
+                "value": "true"
             },
             {
                 "name": "SCREEN_HEIGHT",

--- a/terraform/firefox.task.json
+++ b/terraform/firefox.task.json
@@ -30,8 +30,12 @@
                 "value": "4443"
             },
             {
-                "name": "SE_OPTS",
-                "value": "--override-max-sessions true --max-sessions 6 --session-timeout 7200"
+                "name": "SE_NODE_MAX_SESSIONS",
+                "value": "6"
+            },
+            {
+                "name": "SE_NODE_OVERRIDE_MAX_SESSIONS",
+                "value": "true"
             },
             {
                 "name": "SCREEN_HEIGHT",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -80,12 +80,12 @@ variable "firefox_cpu_scale_in_threshold" {
 
 variable "chrome_cpu_scale_out_threshold" {
   type = number
-  default = 90
+  default = 45
 }
 
 variable "firefox_cpu_scale_out_threshold" {
   type = number
-  default = 90
+  default = 45
 }
 
 variable "chrome_min_tasks" {


### PR DESCRIPTION
Since node max sessions not being picked up, try lower the CPU utilization threshold in hope for triggering scaling up event.