### PR TITLE
turn off edge

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -122,7 +122,7 @@ variable "firefox_min_tasks" {
 
 variable "edge_min_tasks" {
   type = number
-  default = 1
+  default = 0
 }
 
 variable "chrome_max_tasks" {
@@ -137,7 +137,7 @@ variable "firefox_max_tasks" {
 
 variable "edge_max_tasks" {
   type = number
-  default = 4
+  default = 0
 }
 
 variable "hub_cpu" {


### PR DESCRIPTION
There is a weird behavior detected when setting tests to use edge with the selenium grid

https://gitlab.com/casebook-pbc/cbp-fe-automation/-/jobs/2301358727

The above job had perfectly set proper variables for edge test but the selenium hub redirect few sessions to firefox (the console log from the job shows the failure stacktrace with firefox node)

This behavior is not detected with test run for chrome and firefox, I suspect there might be bug in selenium hub and this issue made parallel edge run impossible at this moment.

Create this PR to turn off edge node to save some budget.