### PR TITLE
reduce session timeout

### DIFF
--- a/terraform/chrome.task.json
+++ b/terraform/chrome.task.json
@@ -37,10 +37,6 @@
                 "name": "SE_NODE_OVERRIDE_MAX_SESSIONS",
                 "value": "true"
             },
-            {   
-                "name": "SE_SESSION_REQUEST_TIMEOUT",
-                "value": "7200"
-            },
             {
                 "name": "SCREEN_HEIGHT",
                 "value": "1080"

--- a/terraform/edge.task.json
+++ b/terraform/edge.task.json
@@ -37,10 +37,6 @@
                 "name": "SE_NODE_OVERRIDE_MAX_SESSIONS",
                 "value": "true"
             },
-            {   
-                "name": "SE_SESSION_REQUEST_TIMEOUT",
-                "value": "7200"
-            },
             {
                 "name": "SCREEN_HEIGHT",
                 "value": "1080"

--- a/terraform/firefox.task.json
+++ b/terraform/firefox.task.json
@@ -37,10 +37,6 @@
                 "name": "SE_NODE_OVERRIDE_MAX_SESSIONS",
                 "value": "true"
             },
-            {   
-                "name": "SE_SESSION_REQUEST_TIMEOUT",
-                "value": "7200"
-            },
             {
                 "name": "SCREEN_HEIGHT",
                 "value": "1080"


### PR DESCRIPTION
![Screen Shot 2022-04-07 at 9 29 08 PM](https://user-images.githubusercontent.com/97057252/162346174-5007ea3f-dcdd-4abc-a5bb-92e8cac5e18b.png)
Saw a node session hanging for near two hours.

Try to reduce the session timeout to prevent hanging that long, the default is 5 mins and sound reasonable, so the PR just removed the flag and the node should just use default value.